### PR TITLE
fix(manager): cache funding account 

### DIFF
--- a/harness/manager.go
+++ b/harness/manager.go
@@ -346,15 +346,19 @@ func (tm *TestManager) fundAllParties(
 	ctx context.Context,
 	senders []*SenderWithBabylonClient,
 ) error {
-
-	fundingAccount := tm.BabylonClientNode0.MustGetAddr()
-	fundingAddress := sdk.MustAccAddressFromBech32(fundingAccount)
-
-	var msgs []sdk.Msg
+	msgs := make([]sdk.Msg, 0, len(senders))
 
 	for _, sender := range senders {
-		msg := banktypes.NewMsgSend(fundingAddress, sender.BabylonAddress, types.NewCoins(types.NewInt64Coin("ubbn", 100_000_000)))
+		msg := banktypes.NewMsgSend(
+			tm.fundingAddress,
+			sender.BabylonAddress,
+			types.NewCoins(types.NewInt64Coin("ubbn", 100_000_000)),
+		)
 		msgs = append(msgs, msg)
+	}
+
+	if ctx.Err() != nil {
+		return fmt.Errorf("context error: %w", ctx.Err())
 	}
 
 	resp, err := tm.BabylonClientNode0.ReliablySendMsgs(


### PR DESCRIPTION
Fixes a race condition that happens in `MustAccAddressFromBech32`.