### PR TITLE
chore: fund bbn accounts 

### DIFF
--- a/cmd/datagen/cmd/generate.go
+++ b/cmd/datagen/cmd/generate.go
@@ -17,15 +17,12 @@ const (
 	iavlDisabledFastnode = "iavl-disabled-fastnode"
 	iavlCacheSize        = "iavl-cache-size"
 	numMatureOutputsFlag = "num-mature-outputs"
-	keyName              = "key-name"
-	BabylonAddress       = "babylon-address"
-	grpcaddr             = "grpc-address"
+	keyNameFlag          = "key-name"
 	babylonGRPCaddr      = "babylon-grpc-address"
 	babylonRPCaddr       = "babylon-rpc-address"
 	btcRPCaddr           = "btc-rpc-address"
 	btcpass              = "btc-pass"
 	btcuser              = "btc-user"
-	keys                 = "keys"
 	walletName           = "wallet-name"
 	walletPassphrase     = "wallet-passphrase"
 	keysPath             = "keys-path"
@@ -66,8 +63,8 @@ func CommandGenerateAndSaveKey() *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.String(keyName, "", "Name of the key to generate")
-	if err := cmd.MarkFlagRequired(keyName); err != nil {
+	f.String(keyNameFlag, "", "Name of the key to generate")
+	if err := cmd.MarkFlagRequired(keyNameFlag); err != nil {
 		panic(err)
 	}
 
@@ -262,7 +259,7 @@ func cmdGenerate(cmd *cobra.Command, _ []string) error {
 
 func cmdGenerateAndSaveKeys(cmd *cobra.Command, _ []string) error {
 	flags := cmd.Flags()
-	keyName, err := flags.GetString(keyName)
+	keyName, err := flags.GetString(keyNameFlag)
 
 	if err != nil {
 		return fmt.Errorf("failed to read flag %s: %w", keyName, err)

--- a/cmd/datagen/cmd/generate.go
+++ b/cmd/datagen/cmd/generate.go
@@ -26,6 +26,7 @@ const (
 	walletName           = "wallet-name"
 	walletPassphrase     = "wallet-passphrase"
 	keysPath             = "keys-path"
+	chainIDFlag          = "chain-id"
 )
 
 // CommandGenerate generates data
@@ -124,6 +125,11 @@ func CommandGenerateRemote() *cobra.Command {
 
 	f.Int(totalStakersFlag, 100, "Number of stakers to run (optional)")
 
+	f.String(chainIDFlag, "", "Chain ID")
+	if err := cmd.MarkFlagRequired(chainIDFlag); err != nil {
+		panic(err)
+	}
+
 	return cmd
 }
 
@@ -174,6 +180,11 @@ func cmdGenerateRemote(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to read flag: %s", totalStakersFlag)
 	}
 
+	chainId, err := flags.GetString(chainIDFlag)
+	if err != nil {
+		return fmt.Errorf("failed to read flag: %s", chainIDFlag)
+	}
+
 	cfg := config.Config{
 		BabylonRPC:       babylonRPCaddr,
 		BTCRPC:           btcRPCaddr,
@@ -184,6 +195,7 @@ func cmdGenerateRemote(cmd *cobra.Command, _ []string) error {
 		WalletName:       walletName,
 		WalletPassphrase: walletPassphrase,
 		TotalStakers:     totalStakers,
+		ChainID:          chainId,
 	}
 
 	if err := cfg.ValidateRemote(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	KeysPath               string
 	WalletName             string
 	WalletPassphrase       string
+	ChainID                string
 }
 
 func (c *Config) Validate() error {
@@ -64,6 +65,10 @@ func (c *Config) ValidateRemote() error {
 
 	if c.KeysPath == "" {
 		return fmt.Errorf("keys path should not be empty")
+	}
+
+	if c.ChainID == "" {
+		return fmt.Errorf("chain id should not be empty")
 	}
 
 	return nil

--- a/harness/app.go
+++ b/harness/app.go
@@ -35,6 +35,7 @@ func startRemoteHarness(cmdCtx context.Context, cfg config.Config) error {
 	bbncfg := bncfg.DefaultBabylonConfig()
 	bbncfg.RPCAddr = cfg.BabylonRPC
 	bbncfg.GRPCAddr = cfg.BabylonGRPC
+	bbncfg.ChainID = cfg.ChainID
 	fmt.Printf("📡 Connecting to Babylon at RPC: %s, GRPC: %s\n", cfg.BabylonRPC, cfg.BabylonGRPC)
 
 	bbnClient, err := New(&bbncfg)

--- a/harness/app.go
+++ b/harness/app.go
@@ -46,6 +46,8 @@ func startRemoteHarness(cmdCtx context.Context, cfg config.Config) error {
 	if err != nil {
 		return fmt.Errorf("error importing keys: %w", err)
 	}
+	bbncfg.Key = keys.BabylonKey.KeyName
+	bbncfg.SubmitterAddress = keys.BabylonKey.KeyName
 
 	err = bbnClient.checkFunds(cmdCtx, keys.BabylonKey.Address, cfg.TotalStakers)
 	if err != nil {
@@ -80,6 +82,11 @@ func startRemoteHarness(cmdCtx context.Context, cfg config.Config) error {
 
 		staker := NewBTCStaker(btcClient.client, stakerSender, fpPks, nil, nil)
 		stakers = append(stakers, staker)
+	}
+
+	err = bbnClient.initialFund(cmdCtx, stakers)
+	if err != nil {
+		return fmt.Errorf("failed to initial fund: %w", err)
 	}
 
 	if err := startStakersInBatches(cmdCtx, stakers); err != nil {

--- a/harness/babylonclient.go
+++ b/harness/babylonclient.go
@@ -221,13 +221,6 @@ func (c *Client) importKeys(path string) (*KeyExport, error) {
 		return nil, err
 	}
 
-	if c.provider.PCfg.KeyringBackend == "" {
-		c.provider.PCfg.KeyringBackend = "test"
-	}
-	if c.provider.PCfg.KeyDirectory == "" {
-		c.provider.PCfg.KeyDirectory = "keys/chain-test"
-	}
-
 	_ = c.provider.Keybase.Delete(keys.BabylonKey.KeyName)
 
 	err = c.provider.Keybase.ImportPrivKeyHex(
@@ -289,7 +282,6 @@ func (c *Client) initialFund(ctx context.Context, senders []*BTCStaker) error {
 			fundedAmount,
 		)
 		msgs = append(msgs, msg)
-		fmt.Println("Sending msgs: ", msg)
 	}
 
 	if ctx.Err() != nil {

--- a/harness/babylonclient.go
+++ b/harness/babylonclient.go
@@ -35,7 +35,7 @@ const (
 	// but each staker performs multiple actions.
 	// 8000 ubbn is allocated per staker to include a safety buffer
 	// for retries, additional messages, and fluctuations.
-	amount = 8000
+	StakerFundAmount = 8000
 )
 
 var (
@@ -262,17 +262,17 @@ func (c *Client) initialFund(ctx context.Context, senders []*BTCStaker) error {
 	msgs := make([]sdk.Msg, 0, len(senders))
 	amount := sdk.Coin{
 		Denom:  "ubbn",
-		Amount: math.NewInt(8000)}
+		Amount: math.NewInt(StakerFundAmount)}
 	fundedAmount := sdk.NewCoins(amount)
 
-	addrRecord, err := c.provider.Keybase.Key(c.provider.PCfg.Key)
+	addr, err := c.provider.Address()
 	if err != nil {
-		return fmt.Errorf("could not retrieve key: %w", err)
+		return fmt.Errorf("failed to get address: %w", err)
 	}
 
-	sdkAddr, err := addrRecord.GetAddress()
+	sdkAddr, err := sdk.AccAddressFromBech32(addr)
 	if err != nil {
-		return fmt.Errorf("could not get address: %w", err)
+		return fmt.Errorf("failed to get sdk address: %w", err)
 	}
 
 	for _, sender := range senders {

--- a/harness/babylonclient.go
+++ b/harness/babylonclient.go
@@ -248,7 +248,7 @@ func (c *Client) checkFunds(ctx context.Context, address string, stakers int) er
 		return fmt.Errorf("failed to query balance: %w", err)
 	}
 
-	requiredAmount := math.NewInt(int64(amount * stakers))
+	requiredAmount := math.NewInt(int64(StakerFundAmount * stakers))
 	minimum := sdk.NewCoin("ubbn", requiredAmount)
 
 	if res.Balance.Amount.LT(minimum.Amount) {

--- a/harness/keys.go
+++ b/harness/keys.go
@@ -47,6 +47,7 @@ func GenerateAndSaveKeys(keyName string) (*KeyExport, error) {
 		PubKey:  hex.EncodeToString(pubKey.Bytes()),
 		PrivKey: hex.EncodeToString(privKey.Bytes()),
 		Address: address.String(),
+		KeyName: keyName,
 	}
 
 	btcKey := Key{

--- a/harness/manager.go
+++ b/harness/manager.go
@@ -359,7 +359,7 @@ func (tm *TestManager) fundAllParties(
 		return fmt.Errorf("context error: %w", ctx.Err())
 	}
 
-	for msgsChunk := range slices.Chunk(msgs, 50) {
+	for msgsChunk := range slices.Chunk(msgs, 100) {
 		resp, err := tm.BabylonClientNode0.ReliablySendMsgs(
 			ctx,
 			msgsChunk,


### PR DESCRIPTION
```
WARNING:(ast) sonic only supports go1.17~1.23, but your environment is not suitable
📡 Connecting to Babylon at RPC: https://rpc.devnet.babylonlabs.io, GRPC: grpc.devnet.babylonlabs.io:443
Key imported successfully: signer
submitter address: signer
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1jjyhsgt8aaptzm63t7dttadccc485jnr6gqvv6" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1mashtznthlmg3udmd0wsgg0q0z3jevn49q7mma" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1c9xjsv5pppjq57fu33rqtth5u8ay2erm4sau2g" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1wj9pe8760wg82hdda8q2geyrjjfffl4a3m4hhm" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1cf0zphgxdaq04ngpvpqx6a829pzn2kfc3jv9ry" amount:<denom:"ubbn" amount:"8000" >  msgs
Error: failed to initial fund: unauthorized
Usage:
  dgd generate-remote [flags]

Aliases:
  generate-remote, gr

Examples:
dgd generate-remote --babylon-rpc-address http://localhost:26657 --babylon-grpc-address http://localhost:9090 --btc-rpc-address http://localhost:8332 --keys /path/to/keys --btc-user "username" --btc-pass "btcpassword"

Flags:
      --babylon-grpc-address string   Babylon gRPC address
      --babylon-rpc-address string    Babylon RPC address
      --btc-pass string               Bitcoin RPC password
      --btc-rpc-address string        Bitcoin RPC address
      --btc-user string               Bitcoin RPC user
  -h, --help                          help for generate-remote
      --keys-path string              Path to btc and babylon key pairs that will be used for remote node funding
      --total-stakers int             Number of stakers to run (optional) (default 100)
      --wallet-name string            Wallet name
      --wallet-passphrase string      Wallet passphrase

⚠️: There was an error while executing dgd CLI 'failed to initial fund: unauthorized'
```

another instance

```
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn108fax0ntwttnm95gx0tekx6c2chpzutvs2ch3j" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1p5g45nrrxr9mkgcfq90u76u52xsctsgvha594x" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1mgpm854rycewdp2t63a4mpk4s9mxlps9te5x0m" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn1kvs9h2qttvygecr8hvez4d49584vmjplxvlg0e" amount:<denom:"ubbn" amount:"8000" >  msgs
Sending from_address:"bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj" to_address:"bbn12c6sgejwt7yz62avxkpxmseyurxtm3ydhy7k9h" amount:<denom:"ubbn" amount:"8000" >  msgs
🔑 Using provider key: signer
📁 Using keyring backend: test
📂 Using key directory: keys/chain-test
✅ Key address: bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj
🧾 Msg 0 is MsgSend, signer: bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj
🧾 Msg 1 is MsgSend, signer: bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj
🧾 Msg 2 is MsgSend, signer: bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj
🧾 Msg 3 is MsgSend, signer: bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj
🧾 Msg 4 is MsgSend, signer: bbn1kk4a8ur89e7fh27tv5f3dav0dv34xh0vjg3jvj
📨 Prepared 5 relayer messages
❌ Error sending messages to mempool: unauthorized
Error: failed to initial fund: send error: unauthorized
```